### PR TITLE
fix: correct option pointer for shuffled option

### DIFF
--- a/src/components/buttons/Option.tsx
+++ b/src/components/buttons/Option.tsx
@@ -4,6 +4,7 @@ import TextToSpeechBtn from './TextToSpeechBtn';
 import { Option } from 'types';
 import { addEndingPunctuation } from 'utils';
 import ALL_CONSTANT from 'constants/constant';
+import { getOptionValue } from 'pages/questions/hooks/useQuestionData';
 
 interface OptionProps {
   option: Option;
@@ -22,6 +23,7 @@ export default function OptionBtn({
   isCorrect,
   disabled,
 }: OptionProps) {
+  const optionValue = getOptionValue(option);
   const optionClassname = `flex flex-row items-center justify-between gap-2 rounded-lg p-3 xl:ps-6 ${
     isCorrect
       ? 'bg-lightGreen shadow-sm shadow-green-500'
@@ -45,14 +47,14 @@ export default function OptionBtn({
         disabled={disabled}
       >
         <span className={textClassname}>
-          {option?.word
-            ? addEndingPunctuation(option.word, text('GURMUKHI'))
-            : option?.option || ''}
+          {
+            addEndingPunctuation(optionValue, text('GURMUKHI'))
+          }
         </span>
       </button>
       <TextToSpeechBtn
         backgroundColor='bg-white-175'
-        text={option.word ? option.word : option.option ?? ''}
+        text={optionValue}
         type={ALL_CONSTANT.OPTION}
         id={option.id}
       />

--- a/src/pages/questions/hooks/useQuestionData.tsx
+++ b/src/pages/questions/hooks/useQuestionData.tsx
@@ -1,19 +1,23 @@
 import { useMemo } from 'react';
-import { QuestionData } from 'types';
+import { Option, QuestionData } from 'types';
 import { shuffleArray } from 'pages/dashboard/utils';
+
+const getOptionValue = (option: string | Option) => {
+  if (typeof option === 'string') {
+    return option;
+  }
+  return option.word ?? option.option;
+};
 
 const useQuestionData = (currentQuestion: QuestionData | null) => {
   const memoizedQuestionData = useMemo(() => {
     if (currentQuestion?.options) {
       const correctOption = currentQuestion.options[currentQuestion.answer];
-      const correctAnswer = typeof correctOption === 'string' ? correctOption : correctOption.word;
+      const correctAnswer = getOptionValue(correctOption);
       const shuffledOptions = shuffleArray([...currentQuestion.options]);
       const answer = shuffledOptions.findIndex((option) => {
-        if (typeof option === 'string') {
-          return option === correctAnswer;
-        } else {
-          return option.word === correctAnswer;
-        }
+        const optionValue = getOptionValue(option);
+        return optionValue === correctAnswer;
       });
       const newQData = {
         ...currentQuestion,
@@ -27,4 +31,4 @@ const useQuestionData = (currentQuestion: QuestionData | null) => {
   return memoizedQuestionData;
 };
 
-export default useQuestionData;
+export { getOptionValue, useQuestionData };

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -6,7 +6,7 @@ import metaTags from 'constants/meta';
 import { getQuestionByID } from 'database/default/question';
 import { useAppSelector } from 'store/hooks';
 import Loading from 'components/loading';
-import useQuestionData from './hooks/useQuestionData';
+import { useQuestionData } from './hooks/useQuestionData';
 import { getQuestionElement, renderFooter } from './utils';
 
 export default function Question() {

--- a/src/tests/gameAlgo/useQuestionData.test.ts
+++ b/src/tests/gameAlgo/useQuestionData.test.ts
@@ -3,7 +3,7 @@
  */
 /* eslint-disable no-magic-numbers */
 import { renderHook } from '@testing-library/react';
-import useQuestionData from 'pages/questions/hooks/useQuestionData';
+import { useQuestionData } from 'pages/questions/hooks/useQuestionData';
 import { QuestionData } from 'types';
 
 const currentQuestion: QuestionData = {


### PR DESCRIPTION
This PR fixes the issue of showing correct option as wrong when options are shuffled.
It handles the condtion where option.word was returning undefined and option.option contains the required value instead.